### PR TITLE
Fix fast_finish indentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     - realpath
 
 jobs:
+  fast_finish: true
   include:
    # Libraries
    - stage: "Libraries"
@@ -102,8 +103,6 @@ jobs:
      os: windows
      env:
      - PACKAGE=prog/iceprog
-
-   fast_finish: true
 
 before_install:
  - source $TRAVIS_BUILD_DIR/.travis/common.sh


### PR DESCRIPTION
This makes Travis CI working again. It's also moved right under 'jobs'
as it's not easy to spot it or verify indentation after all jobs.