### PR TITLE
Remove excessive `resolved_packages`

### DIFF
--- a/prog/flterm/meta.yaml
+++ b/prog/flterm/meta.yaml
@@ -19,10 +19,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-  run:
-  {% for package in resolved_packages('host') %}
-    - {{ package }}
-  {% endfor %}
 
 test:
   commands:


### PR DESCRIPTION
There are no `host` requirements so this is completely excessive.