### PR TITLE
Fix recipes to only use Conda-based tools

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -221,7 +221,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - run: brew install coreutils autoconf automake libtool
       - uses: litex-hub/litex-conda-ci@master
 
   #18

--- a/lib/ftdi/meta.yaml
+++ b/lib/ftdi/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - python
     - {{ compiler('c') }}   [not win]
     - {{ compiler('cxx') }} [not win]
+    - make                  [not win]
     - pkg-config            [not win]
     - cmake
   host:

--- a/lib/usb/meta.yaml
+++ b/lib/usb/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - {{ compiler('c') }}
     - automake  [not win]
     - autoconf  [not win]
+    - make      [not win]
   host:
     - pkg-config [not win]
 

--- a/tools/dfu-util/meta.yaml
+++ b/tools/dfu-util/meta.yaml
@@ -19,7 +19,12 @@ build:
 
 requirements:
   build:
+    # On macOS `autoconf`, `automake`, `coreutils`
+    # and `libtool` need to be installed from brew.
     - {{ compiler('c') }}
+    - autoconf    [linux]
+    - automake    [linux]
+    - make        [linux]
     - pkg-config
   host:
     - libusb

--- a/tools/flterm/build.sh
+++ b/tools/flterm/build.sh
@@ -7,5 +7,5 @@ fi
 set -x
 set -e
 
-make CC="gcc -I."
+make CC="$CC -I."
 make PREFIX=$PREFIX install

--- a/tools/flterm/meta.yaml
+++ b/tools/flterm/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - make
 
 test:
   commands:

--- a/tools/fxload/meta.yaml
+++ b/tools/fxload/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - make
     - pkg-config
   host:
     - libusb

--- a/tools/icefunprog/build.sh
+++ b/tools/icefunprog/build.sh
@@ -9,6 +9,10 @@ fi
 
 unset CFLAGS
 
+cd "$BUILD_PREFIX/bin"
+ln -s "$CC" gcc
+cd -
+
 make -j$CPU_COUNT
 
 make install

--- a/tools/icefunprog/meta.yaml
+++ b/tools/icefunprog/meta.yaml
@@ -25,6 +25,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - make
     - pkg-config
   host: []
   run: []

--- a/tools/iceprog/meta.yaml
+++ b/tools/iceprog/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - pkg-config      [not win]
+    - make            [not win]
     - m2w64-toolchain [win]
     - m2-base         [win]
     - m2-make         [win]

--- a/tools/openocd/meta.yaml
+++ b/tools/openocd/meta.yaml
@@ -30,6 +30,9 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - automake
+    - libtool
+    - make
     - pkg-config
   host:
     - libftdi


### PR DESCRIPTION
After trying to build the recipes on a clean Docker container created from the `ubuntu` image it turned out many of them are relying on the tools preinstalled in the Travis and GitHub Actions Operating Systems.

The changes make all of the recipes buildable without requiring any additional build tools installed in the container.

The changes turned out to be enough to dump installing additional packages through `brew` for `openocd` package on macOS.