### PR TITLE
Fix master-package.sh behavior

### DIFF
--- a/lib/xml2/meta.yaml
+++ b/lib/xml2/meta.yaml
@@ -13,7 +13,8 @@ source:
     - 0004-CVE-2017-8872.patch
 
 build:
-  number: 5
+  number: {{ environ.get('DATE_NUM') }}
+  string: {{ environ.get('DATE_STR') }}
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/


### PR DESCRIPTION
This PR bumps submodule. This bump fixes conditional master-package.sh execution. Packages shall be uploaded only when building for master branch.