### PR TITLE
ci: use a reusable workflow, instead of waiting and counting jobs

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,27 +1,16 @@
-name: build-packages
+name: Build packages
+
 on:
-  push:
-    # Prevents triggering multiple workflows in PRs. Workflows triggered from
-    # the same commit shouldn't run simultaneously because they're overwriting
-    # each other's packages on Anaconda.
-    branches: [ master ]
-    paths-ignore:
-      - '.github/workflows/tuttest.yml'
-      - 'README.md'
-  pull_request:
-    paths-ignore:
-      - '.github/workflows/tuttest.yml'
-      - 'README.md'
-  workflow_dispatch:
-  schedule:
-    - cron: '0 1 * * *' # run daily at 1:00am (UTC)
+  workflow_call:
+
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}
-  NUM_OF_JOBS: 24
+
 defaults:
   run:
     shell: bash
+
 jobs:
 
   #1
@@ -279,26 +268,3 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: hdl/conda-eda/ci@master
-
-
-  master-package:
-    runs-on: "ubuntu-20.04"
-    env:
-      OS_NAME: "linux"
-      CI_SCRIPTS_REL_PATH: "conda-eda"
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: hdl/conda-eda
-          ref: master
-          path: ${{ env.CI_SCRIPTS_REL_PATH }}
-      - uses: actions/setup-python@v1
-      - uses: BSFishy/pip-action@v1
-        with:
-          packages: urllib3
-      - run: |
-          # Required internally by the scripts to locate other scripts.
-          export CI_SCRIPTS_PATH="$GITHUB_WORKSPACE/$CI_SCRIPTS_REL_PATH/ci"
-          bash $CI_SCRIPTS_PATH/install.sh
-          python $CI_SCRIPTS_PATH/wait-for-statuses.py

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -20,7 +20,7 @@ jobs:
       PACKAGE: "lib/usb"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #2
@@ -31,7 +31,7 @@ jobs:
       PACKAGE: "lib/hidapi"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #3
@@ -41,7 +41,7 @@ jobs:
       PACKAGE: "lib/xml2"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #4
@@ -51,7 +51,7 @@ jobs:
       PACKAGE: "tools/icefunprog"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #5
@@ -61,7 +61,7 @@ jobs:
       PACKAGE: "tools/flterm"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #6
@@ -72,7 +72,7 @@ jobs:
       PACKAGE: "lib/ftdi"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #7
@@ -83,7 +83,7 @@ jobs:
       PACKAGE: "tools/fxload"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #8
@@ -94,7 +94,7 @@ jobs:
       PACKAGE: "tools/dfu-util"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #9
@@ -105,7 +105,7 @@ jobs:
       PACKAGE: "tools/iceprog"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #10
@@ -116,7 +116,7 @@ jobs:
       PACKAGE: "tools/openocd"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #11
@@ -127,7 +127,7 @@ jobs:
       PACKAGE: "tools/openfpgaloader"
       OS_NAME: "linux"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #12
@@ -137,7 +137,7 @@ jobs:
       PACKAGE: "lib/usb"
       OS_NAME: "osx"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #13
@@ -148,7 +148,7 @@ jobs:
       PACKAGE: "lib/hidapi"
       OS_NAME: "osx"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #14
@@ -158,7 +158,7 @@ jobs:
       PACKAGE: "lib/xml2"
       OS_NAME: "osx"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #15
@@ -168,7 +168,7 @@ jobs:
       PACKAGE: "tools/icefunprog"
       OS_NAME: "osx"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #16
@@ -178,7 +178,7 @@ jobs:
       PACKAGE: "tools/flterm"
       OS_NAME: "osx"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #17
@@ -189,7 +189,7 @@ jobs:
       PACKAGE: "lib/ftdi"
       OS_NAME: "osx"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #18
@@ -200,7 +200,7 @@ jobs:
       PACKAGE: "tools/dfu-util"
       OS_NAME: "osx"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: brew install coreutils autoconf automake libtool
       - uses: hdl/conda-eda/ci@master
 
@@ -212,7 +212,7 @@ jobs:
       PACKAGE: "tools/iceprog"
       OS_NAME: "osx"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #20
@@ -223,7 +223,7 @@ jobs:
       PACKAGE: "tools/openocd"
       OS_NAME: "osx"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #21
@@ -233,7 +233,7 @@ jobs:
       PACKAGE: "lib/usb"
       OS_NAME: "windows"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #22
@@ -244,7 +244,7 @@ jobs:
       PACKAGE: "lib/hidapi"
       OS_NAME: "windows"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #23
@@ -255,7 +255,7 @@ jobs:
       PACKAGE: "lib/ftdi"
       OS_NAME: "windows"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master
 
   #24
@@ -266,5 +266,5 @@ jobs:
       PACKAGE: "tools/iceprog"
       OS_NAME: "windows"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hdl/conda-eda/ci@master

--- a/.github/workflows/Upload.yml
+++ b/.github/workflows/Upload.yml
@@ -1,0 +1,58 @@
+name: Upload packages
+
+on:
+  push:
+    # Prevents triggering multiple workflows in PRs. Workflows triggered from
+    # the same commit shouldn't run simultaneously because they're overwriting
+    # each other's packages on Anaconda.
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 23 * * *' # run daily at 23:00 (UTC)
+
+env:
+  ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+  ANACONDA_USER: ${{ secrets.ANACONDA_USER }}
+  OS_NAME: linux
+  CI_SCRIPTS_REL_PATH: "conda-eda"
+
+jobs:
+
+
+  Build:
+    uses: ./.github/workflows/Build.yml
+
+
+  Upload:
+    needs: Build
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: hdl/conda-eda
+          ref: master
+          path: ${{ env.CI_SCRIPTS_REL_PATH }}
+      - run: |
+          # Required internally by the scripts to locate other scripts.
+          export CI_SCRIPTS_PATH="$GITHUB_WORKSPACE/$CI_SCRIPTS_REL_PATH/ci"
+          "$CI_SCRIPTS_PATH"/install.sh
+          "$CI_SCRIPTS_PATH"/upload-packages.sh
+
+
+  Cleanup:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: hdl/conda-eda
+          ref: master
+          path: ${{ env.CI_SCRIPTS_REL_PATH }}
+      - run: |
+          # Required internally by the scripts to locate other scripts.
+          export CI_SCRIPTS_PATH="$GITHUB_WORKSPACE/$CI_SCRIPTS_REL_PATH/ci"
+          "$CI_SCRIPTS_PATH"/install.sh
+          "$CI_SCRIPTS_PATH"/cleanup-anaconda.sh


### PR DESCRIPTION
Ref hdl/conda-eda#216